### PR TITLE
fiX：锁定及提升版本

### DIFF
--- a/.github/workflows/checkin.yml
+++ b/.github/workflows/checkin.yml
@@ -14,22 +14,22 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '16.x'
       - name: install axios
-        run: npm install axios
+        run: npm install axios@1.1.3
       - name: install puppeteer-extra-plugin-stealth
-        run: npm install puppeteer puppeteer-extra puppeteer-extra-plugin-stealth
+        run: npm install puppeteer@19.0.0 puppeteer-extra@3.3.4 puppeteer-extra-plugin-stealth@2.11.1
       - name: CheckIn
         run: node checkin.js
         env:
           PUSHPLUS: ${{ secrets.PUSHPLUS }}
           COOKIES: ${{ secrets.COOKIES }}
       - name: keep alive
-        uses: gautamkrishnar/keepalive-workflow@master # using the workflow with default settings
+        uses: gautamkrishnar/keepalive-workflow@v1 # using the workflow with default settings
       - name: Delete workflow runs
         uses: Mattraks/delete-workflow-runs@v2
         with:


### PR DESCRIPTION
感谢您对 GLaDOS-CheckIn 存储库的贡献。

## 变更类型

请删除不相关的选项。

- [x] 修复错误（修复问题的非破坏性更改）

## 描述

puppeteer更新19.1.0，导致报错：

>Error: An `executablePath` or `channel` must be specified for `puppeteer-core`

- puppeteer锁定为19.0.0
- 相关包锁定版本
- 部分包升级版本，消除action-summary中关于node12的警告
  - gautamkrishnar/keepalive-workflow 最新版本仍在使用node12

相关的 issue:

- #56

## 检查清单

- [x] 我对自己的代码进行了自我审查
- [x] 我在可能难以理解的地方进行了注释
- [x] 我在需要的情况下对文档做了相应的修改
