### PR TITLE
fix: 按结论删除工作流

### DIFF
--- a/.github/workflows/checkin.yml
+++ b/.github/workflows/checkin.yml
@@ -37,4 +37,4 @@ jobs:
           repository: ${{ github.repository }}
           retain_days: 0
           keep_minimum_runs: 10
-          delete_workflow_by_state_pattern: success
+          delete_run_by_conclusion_pattern: success


### PR DESCRIPTION
感谢您对 GLaDOS-CheckIn 存储库的贡献。

## 变更类型

请删除不相关的选项。

- [x] 修复错误（修复问题的非破坏性更改）

## 描述

`delete_workflow_by_state_pattern` 选项： active，deleted，disabled_fork，disabled_inactivity，disabled_manually，不支持删除已成功的工作流。

修改成最近更新的`delete_run_by_conclusion_pattern`选项。

相关的 issue:

- #(issue)

## 检查清单

- [x] 我对自己的代码进行了自我审查
- [x] 我在可能难以理解的地方进行了注释
- [x] 我在需要的情况下对文档做了相应的修改
